### PR TITLE
Fix reference to global object; Use native requestAnimationFrame

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-var bind = Function.prototype.bind
+var global = typeof global !== "undefined" ? global : window;
 
 /**
  * `requestAnimationFrame()`
  */
 
-var request = this.requestAnimationFrame
-  || this.webkitRequestAnimationFrame
-  || this.mozRequestAnimationFrame
+var request = global.requestAnimationFrame
+  || global.webkitRequestAnimationFrame
+  || global.mozRequestAnimationFrame
   || fallback
 
 var prev = +new Date
@@ -21,15 +21,10 @@ function fallback (fn) {
  * `cancelAnimationFrame()`
  */
 
-var cancel = this.cancelAnimationFrame
-  || this.webkitCancelAnimationFrame
-  || this.mozCancelAnimationFrame
+var cancel = global.cancelAnimationFrame
+  || global.webkitCancelAnimationFrame
+  || global.mozCancelAnimationFrame
   || clearTimeout
-
-if (bind) {
-  request = bind.call(request, this)
-  cancel = bind.call(cancel, this)
-}
 
 exports = module.exports = request
 exports.cancel = cancel

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var global = typeof global !== "undefined" ? global : window;
+var global = require("global")
 
 /**
  * `requestAnimationFrame()`
@@ -25,6 +25,11 @@ var cancel = global.cancelAnimationFrame
   || global.webkitCancelAnimationFrame
   || global.mozCancelAnimationFrame
   || clearTimeout
+
+if (Function.prototype.bind) {
+  request = request.bind(global)
+  cancel = cancel.bind(global)
+}
 
 exports = module.exports = request
 exports.cancel = cancel

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "url": "git+https://github.com/michaelrhodes/raf.git"
   },
   "author": "Michael Rhodes",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "global": "^4.3.0"
+  }
 }


### PR DESCRIPTION
When exported from a module (at least through browserify), `this` doesn't point to the `window` object in a browser environment. As a result, `rafl` points to `fallback` as `requestAnimationFrame` is `undefined` on `this`.

In fact, this doesn't just happen through browserify, but natively in node. `this` points to the `module` object within a module.

---

I came across this when I noticed that my animations were running erratically (I replaced `raf-component` with `rafl` in other parts of my code), and debugging pointed to `rafl` running `fallback`

Also, this code isn't tested, and is probably not ideal – I just needed a way to file this bug, and issues were not enabled on this repo (but PRs are)
